### PR TITLE
fix(all): issue with configure method on empty object fixed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,11 @@ function config(loader, appHost, configModuleId) {
   aurelia.host = appHost;
 
   if (configModuleId) {
-    return loader.loadModule(configModuleId).then(customConfig => customConfig.configure(aurelia));
+    return loader.loadModule(configModuleId).then(customConfig => {
+      if (customConfig.configure) {
+       return customConfig.configure(aurelia); 
+      }
+    });
   }
 
   aurelia.use


### PR DESCRIPTION
I recently encountered this issue detailed here: https://github.com/aurelia/bootstrapper-webpack/issues/2 - the problem is the configure method is called on what appears to be an empty object. What causes this empty object I could not find. The simple fix seems to be to check for the existence of the configure method on the object and call it if it exists. A minor tweak and there appears to be no side-effects of implementing this.
